### PR TITLE
Install Kafka Before UrbanOS

### DIFF
--- a/.env
+++ b/.env
@@ -48,4 +48,6 @@ JUNO_RESOURCE_PREFIX=""
 #   You'll need to manually trust the staging CA to view the resulting sites.
 # prod letsencrypt usage limits: https://letsencrypt.org/docs/rate-limits/
 # staging usage limits: https://letsencrypt.org/docs/staging-environment/
+# not included in github environemnt secrets, since it's specified in workflow
+#   kickoff.
 JUNO_USE_STAGING_LETS_ENCRYPT="false"

--- a/.env
+++ b/.env
@@ -19,8 +19,9 @@ JUNO_DEMO_AZURE_APP_ID=""
 JUNO_DEMO_AZURE_PASSWORD=""
 JUNO_DEMO_AZURE_TENANT=""
 
-# https://app.terraform.io/app/settings/tokens
+# https://app.terraform.io/app/settings/tokens (user scope)
 JUNO_DEMO_TF_BACKEND_KEY=""
+JUNO_DEMO_TF_WORKSPACE_NAME=""
 
 JUNO_RAPTOR_AUTH0_CLIENT_SECRET=""
 JUNO_ANDI_AUTH0_CLIENT_SECRET=""
@@ -33,3 +34,4 @@ AUTH0_USER_API_KEY=""
 
 # If you add values here, ensure they're also added to 
 # deploy_urbanos.yml / teardown_urbanos.yml as well
+

--- a/.env
+++ b/.env
@@ -14,12 +14,6 @@ JUNO_RESOURCE_PREFIX=""
 JUNO_DOMAIN_NO_SUFFIX="cooldomain"
 JUNO_DOMAIN_WITH_SUFFIX="cooldomain.com"
 
-# demoMode is intended for github actions execution and effecting
-#     demo-urbanos.com resources. Should not be enabled in other
-#     contexts or if developers are running the script locally for other 
-#     subdomains.
-JUNO_DEMO_MODE_ENABLED="false"
-
 # az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/{subscription_id}"
 JUNO_DEMO_AZURE_APP_ID=""
 JUNO_DEMO_AZURE_PASSWORD=""

--- a/.env
+++ b/.env
@@ -1,37 +1,51 @@
-# The azure subscription id that resources will be deployed to
+# note: If you add values here, ensure they're also added to 
+# deploy_urbanos.yml / teardown_urbanos.yml as well as the repo actions 
+# environment
+
+# Auth0 User API Key, pulled from user metadata. Used to connect to disc-streams
+#   by "streams-to-eventhub"
+AUTH0_USER_API_KEY=""
+
+# links andi to auth0
+JUNO_ANDI_AUTH0_CLIENT_SECRET=""
+
+# The azure subscription that resources will be deployed to
+#   `az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/{subscription_id}"`
 JUNO_AZURE_SUB_ID=""
+JUNO_DEMO_AZURE_APP_ID=""
+JUNO_DEMO_AZURE_PASSWORD=""
+JUNO_DEMO_AZURE_TENANT=""
+
+# If these are ommited, a local state file will be used instead of terraform.io
+#   for remote state.
+#   https://app.terraform.io/app/settings/tokens (user scope)
+JUNO_DEMO_TF_BACKEND_KEY=""
+JUNO_DEMO_TF_WORKSPACE_NAME=""
+
+# The value of a domain that has been registered with Azure nameservers, and
+#   has a created dnszone on the resource group shared by the cluster.
+JUNO_DOMAIN_NO_SUFFIX="cooldomain"
+JUNO_DOMAIN_WITH_SUFFIX="cooldomain.com"
+
+# if populated, streams-to-event-hub image will be deployed, which relays
+#   a streams topic created in "initialize-andi" gh action step
+#   into this provided event hub url
+JUNO_EVENT_HUB_URL=""
+
+# used to connect raptor to auth0. Many UrbanOS services use raptor to validate
+#   user info.
+JUNO_RAPTOR_AUTH0_CLIENT_SECRET=""
 
 # used to tag resources. It must be unique from other users deploying juno 
 #     terraform, so that there are no resource conflicts if multiple deployments
 #     are using the same subscription. Choose a unique name.
 JUNO_RESOURCE_PREFIX=""
 
-# The value of a domain that has been registered with Azure nameservers. 
-# You could also populate this value with something you don't own on a domain
-#     registry, and try to access it by setting your host file to azure 
-#     nameservers. See "do I need to buy a domain name".
-#     "https://learn.microsoft.com/en-us/azure/dns/dns-faq#do-i-need-to-buy-a-dns-domain-name-to-use-azure-dns--"
-JUNO_DOMAIN_NO_SUFFIX="cooldomain"
-JUNO_DOMAIN_WITH_SUFFIX="cooldomain.com"
-
-# az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/{subscription_id}"
-JUNO_DEMO_AZURE_APP_ID=""
-JUNO_DEMO_AZURE_PASSWORD=""
-JUNO_DEMO_AZURE_TENANT=""
-
-# https://app.terraform.io/app/settings/tokens (user scope)
-JUNO_DEMO_TF_BACKEND_KEY=""
-JUNO_DEMO_TF_WORKSPACE_NAME=""
-
-JUNO_RAPTOR_AUTH0_CLIENT_SECRET=""
-JUNO_ANDI_AUTH0_CLIENT_SECRET=""
-
-# if populated, streams-to-event-hub image will be deployed, which relays
-#   a streams topic into this provided event hub url
-JUNO_EVENT_HUB_URL=""
-
-AUTH0_USER_API_KEY=""
-
-# If you add values here, ensure they're also added to 
-# deploy_urbanos.yml / teardown_urbanos.yml as well
-
+# if set to "true", cert manager will use staging lets encrypt instead of prod.
+#   staging certs undergo the same service validations, and are valid https connections,
+#   but are issued from an untrusted CA. Prod certs have rate limits.
+#   Staging is best for testing, to avoid approaching weekly prod rate limits.
+#   You'll need to manually trust the staging CA to view the resulting sites.
+# prod letsencrypt usage limits: https://letsencrypt.org/docs/rate-limits/
+# staging usage limits: https://letsencrypt.org/docs/staging-environment/
+JUNO_USE_STAGING_LETS_ENCRYPT="false"

--- a/.github/workflows/deploy_urbanos.yml
+++ b/.github/workflows/deploy_urbanos.yml
@@ -56,6 +56,7 @@ jobs:
           JUNO_DOMAIN_WITH_SUFFIX: ${{secrets.JUNO_DOMAIN_WITH_SUFFIX}}
           JUNO_EVENT_HUB_URL: ${{secrets.JUNO_EVENT_HUB_URL}}
           JUNO_RAPTOR_AUTH0_CLIENT_SECRET: ${{secrets.JUNO_RAPTOR_AUTH0_CLIENT_SECRET}}
+          JUNO_RESOURCE_PREFIX: ${{secrets.JUNO_RESOURCE_PREFIX}}
           JUNO_USE_STAGING_LETS_ENCRYPT: ${{github.event.inputs.use-staging-lets-encrypt}}
 
       - name: Initialize Andi Sample Datasets

--- a/.github/workflows/deploy_urbanos.yml
+++ b/.github/workflows/deploy_urbanos.yml
@@ -43,8 +43,7 @@ jobs:
           commentOnPr: false
         env:
           # ensure edits to these are added to the "teardown_urbanos" workflow as well
-          # in order of env secrets of github action settings
-          JUNO_RESOURCE_PREFIX: ${{secrets.JUNO_RESOURCE_PREFIX}}
+          # in order of .env file secrets and of github action secrets list
           AUTH0_USER_API_KEY: ${{secrets.AUTH0_USER_API_KEY}}
           JUNO_ANDI_AUTH0_CLIENT_SECRET: ${{secrets.JUNO_ANDI_AUTH0_CLIENT_SECRET}}
           JUNO_AZURE_SUB_ID: ${{secrets.JUNO_AZURE_SUB_ID}}
@@ -52,6 +51,7 @@ jobs:
           JUNO_DEMO_AZURE_PASSWORD: ${{secrets.JUNO_DEMO_AZURE_PASSWORD}}
           JUNO_DEMO_AZURE_TENANT: ${{secrets.JUNO_DEMO_AZURE_TENANT}}
           JUNO_DEMO_TF_BACKEND_KEY: ${{secrets.JUNO_DEMO_TF_BACKEND_KEY}}
+          JUNO_DEMO_TF_WORKSPACE_NAME: ${{secrets.JUNO_DEMO_TF_WORKSPACE_NAME}}
           JUNO_DOMAIN_NO_SUFFIX: ${{secrets.JUNO_DOMAIN_NO_SUFFIX}}
           JUNO_DOMAIN_WITH_SUFFIX: ${{secrets.JUNO_DOMAIN_WITH_SUFFIX}}
           JUNO_EVENT_HUB_URL: ${{secrets.JUNO_EVENT_HUB_URL}}

--- a/.github/workflows/deploy_urbanos.yml
+++ b/.github/workflows/deploy_urbanos.yml
@@ -6,6 +6,9 @@ on:
       skip-andi-init:
         type: boolean
         description: Skip initializing andi. Useful to enable this if Andi has already been initialized, and you'd only like to apply the terraform.
+      use-staging-lets-encrypt:
+        type: boolean
+        description: Use staging lets encrypt instead of prod. When enabled, deployments of juno won't count towards the 5 prod certs a week rate limit. More info in the .env file.
 
 jobs:
   Deploy_UrbanOS:
@@ -33,9 +36,9 @@ jobs:
           commentOnPr: false
         env:
           # ensure edits to these are added to the "teardown_urbanos" workflow as well
+          # in order of env secrets of github action settings
           JUNO_DEMO_MODE_ENABLED: ${{vars.JUNO_DEMO_MODE_ENABLED}}
           JUNO_RESOURCE_PREFIX: ${{vars.JUNO_RESOURCE_PREFIX}}
-          # in order of env secrets of github action settings
           AUTH0_USER_API_KEY: ${{secrets.AUTH0_USER_API_KEY}}
           JUNO_ANDI_AUTH0_CLIENT_SECRET: ${{secrets.JUNO_ANDI_AUTH0_CLIENT_SECRET}}
           JUNO_AZURE_SUB_ID: ${{secrets.JUNO_AZURE_SUB_ID}}
@@ -47,6 +50,7 @@ jobs:
           JUNO_DOMAIN_WITH_SUFFIX: ${{secrets.JUNO_DOMAIN_WITH_SUFFIX}}
           JUNO_EVENT_HUB_URL: ${{secrets.JUNO_EVENT_HUB_URL}}
           JUNO_RAPTOR_AUTH0_CLIENT_SECRET: ${{secrets.JUNO_RAPTOR_AUTH0_CLIENT_SECRET}}
+          JUNO_USE_STAGING_LETS_ENCRYPT: ${{github.event.inputs.use-staging-lets-encrypt}}
 
       - name: Initialize Andi Sample Datasets
         if: ${{ github.event.inputs.skip-andi-init != 'true' }}

--- a/.github/workflows/deploy_urbanos.yml
+++ b/.github/workflows/deploy_urbanos.yml
@@ -9,11 +9,18 @@ on:
       use-staging-lets-encrypt:
         type: boolean
         description: Use staging lets encrypt instead of prod. When enabled, deployments of juno won't count towards the 5 prod certs a week rate limit. More info in the .env file.
+      environment:
+        type: choice
+        description: Choose the environment used to deploy urbanos.
+        options:
+          - demo-urbanos.com
+          - dev1-urbanos.com
+        required: true
 
 jobs:
   Deploy_UrbanOS:
     runs-on: ubuntu-latest
-    environment: Actions
+    environment: ${{ github.event.inputs.environment }}
     steps:
       - uses: actions/checkout@v2
 
@@ -37,8 +44,7 @@ jobs:
         env:
           # ensure edits to these are added to the "teardown_urbanos" workflow as well
           # in order of env secrets of github action settings
-          JUNO_DEMO_MODE_ENABLED: ${{vars.JUNO_DEMO_MODE_ENABLED}}
-          JUNO_RESOURCE_PREFIX: ${{vars.JUNO_RESOURCE_PREFIX}}
+          JUNO_RESOURCE_PREFIX: ${{secrets.JUNO_RESOURCE_PREFIX}}
           AUTH0_USER_API_KEY: ${{secrets.AUTH0_USER_API_KEY}}
           JUNO_ANDI_AUTH0_CLIENT_SECRET: ${{secrets.JUNO_ANDI_AUTH0_CLIENT_SECRET}}
           JUNO_AZURE_SUB_ID: ${{secrets.JUNO_AZURE_SUB_ID}}

--- a/.github/workflows/deploy_urbanos.yml
+++ b/.github/workflows/deploy_urbanos.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       skip-andi-init:
         type: boolean
-        description: Skip initializing andi. Useful to enable this if Andi has already been initialized, and you'd only like to apply the terraform.
+        description: Skip initializing andi. Enable this skip if not deploying to demo-urbanos.com. Useful to enable this if Andi has already been initialized, and you'd only like to apply the terraform.
       use-staging-lets-encrypt:
         type: boolean
         description: Use staging lets encrypt instead of prod. When enabled, deployments of juno won't count towards the 5 prod certs a week rate limit. More info in the .env file.

--- a/.github/workflows/teardown_urbanos.yml
+++ b/.github/workflows/teardown_urbanos.yml
@@ -37,7 +37,7 @@ jobs:
           commentOnPr: false
         env:
           # ensure edits to these are added to the "teardown_urbanos" workflow as well
-          # in order of env secrets of github action settings and .env file
+          # in order of .env file secrets and of github action secrets list
           AUTH0_USER_API_KEY: ${{secrets.AUTH0_USER_API_KEY}}
           JUNO_ANDI_AUTH0_CLIENT_SECRET: ${{secrets.JUNO_ANDI_AUTH0_CLIENT_SECRET}}
           JUNO_AZURE_SUB_ID: ${{secrets.JUNO_AZURE_SUB_ID}}

--- a/.github/workflows/teardown_urbanos.yml
+++ b/.github/workflows/teardown_urbanos.yml
@@ -2,11 +2,19 @@ name: Teardown UrbanOS
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: Choose the environment used to deploy urbanos.
+        options:
+          - demo-urbanos.com
+          - dev1-urbanos.com
+        required: true
 
 jobs:
   Teardown_UrbanOS:
     runs-on: ubuntu-latest
-    environment: Actions
+    environment: ${{ github.event.inputs.environment }}
     steps:
       - uses: actions/checkout@v2
 
@@ -42,5 +50,5 @@ jobs:
           JUNO_DOMAIN_WITH_SUFFIX: ${{secrets.JUNO_DOMAIN_WITH_SUFFIX}}
           JUNO_EVENT_HUB_URL: ${{secrets.JUNO_EVENT_HUB_URL}}
           JUNO_RAPTOR_AUTH0_CLIENT_SECRET: ${{secrets.JUNO_RAPTOR_AUTH0_CLIENT_SECRET}}
-          JUNO_RESOURCE_PREFIX: ${{vars.JUNO_RESOURCE_PREFIX}}
+          JUNO_RESOURCE_PREFIX: ${{secrets.JUNO_RESOURCE_PREFIX}}
           JUNO_USE_STAGING_LETS_ENCRYPT: does_not_matter

--- a/.github/workflows/teardown_urbanos.yml
+++ b/.github/workflows/teardown_urbanos.yml
@@ -29,9 +29,7 @@ jobs:
           commentOnPr: false
         env:
           # ensure edits to these are added to the "teardown_urbanos" workflow as well
-          JUNO_DEMO_MODE_ENABLED: ${{vars.JUNO_DEMO_MODE_ENABLED}}
-          JUNO_RESOURCE_PREFIX: ${{vars.JUNO_RESOURCE_PREFIX}}
-          # in order of env secrets of github action settings
+          # in order of env secrets of github action settings and .env file
           AUTH0_USER_API_KEY: ${{secrets.AUTH0_USER_API_KEY}}
           JUNO_ANDI_AUTH0_CLIENT_SECRET: ${{secrets.JUNO_ANDI_AUTH0_CLIENT_SECRET}}
           JUNO_AZURE_SUB_ID: ${{secrets.JUNO_AZURE_SUB_ID}}
@@ -39,7 +37,10 @@ jobs:
           JUNO_DEMO_AZURE_PASSWORD: ${{secrets.JUNO_DEMO_AZURE_PASSWORD}}
           JUNO_DEMO_AZURE_TENANT: ${{secrets.JUNO_DEMO_AZURE_TENANT}}
           JUNO_DEMO_TF_BACKEND_KEY: ${{secrets.JUNO_DEMO_TF_BACKEND_KEY}}
+          JUNO_DEMO_TF_WORKSPACE_NAME: ${{secrets.JUNO_DEMO_TF_WORKSPACE_NAME}}
           JUNO_DOMAIN_NO_SUFFIX: ${{secrets.JUNO_DOMAIN_NO_SUFFIX}}
           JUNO_DOMAIN_WITH_SUFFIX: ${{secrets.JUNO_DOMAIN_WITH_SUFFIX}}
           JUNO_EVENT_HUB_URL: ${{secrets.JUNO_EVENT_HUB_URL}}
           JUNO_RAPTOR_AUTH0_CLIENT_SECRET: ${{secrets.JUNO_RAPTOR_AUTH0_CLIENT_SECRET}}
+          JUNO_RESOURCE_PREFIX: ${{vars.JUNO_RESOURCE_PREFIX}}
+          JUNO_USE_STAGING_LETS_ENCRYPT: does_not_matter

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ tsconfig.tsbuildinfo
 juno_kube_config
 kubecm.config
 
-helm_template_output.yaml
+helm_urbanos_template_output.yaml
+helm_kafka_template_output.yaml
 
 .DS_Store
 graph.png

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ those references can be made in "configuration.ts"
   that helm uninstalls everything + manually deletes pvcs + secrets, then runs
   the terraform apply action again to create only the helm releases and reuse
   existing azure resources.
+- Vault is not deployed to this environment, so the Andi "add secret" step
+  will fail in configuring ingestions if attempted.
 - The environment can be stood up 5 times a week.
   - This is because we're regenerating certs for ingresses upon environment
     start. Lets Encrypt allows for 5 generations per specific URL. See

--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ those references can be made in "configuration.ts"
     json. The URL is hardcoded to demo-urbanos.com in a few places.
 - Images are pinned at January 30th 2023. Upgrading to newer versions will
   require:
-  - upgrading the urbanos chart version installed in helm.ts
+  - upgrading the urbanos chart version installed in the urbanos release in helm.ts
+  - upgrading the kafka chart version installed in the kafka release in helm.ts
   - altering urbanos_demo_chart_values to correspond with this new chart version
+  - altering urbanos_kafka_values to correspond with this new chart version
+  - updating the version pin in the helm template script in "scripts"
   - pinning each urbanos image in urbanos_demo_chart_values at a release tag
     (or preferably, pinning those in the charts repo itself. Upgrading all
     environments would be much smoother if charts didn't always point to

--- a/scripts/helm_template.sh
+++ b/scripts/helm_template.sh
@@ -11,6 +11,7 @@ the latest remote UrbanOS chart, to \"helm_template_output.yaml\".
 printf >&2 '%s ' 'Enter to continue'
 read ans
 
-helm template urbanos urbanos/urban-os -f src/urbanos_demo_chart_values.yaml > helm_template_output.yaml
+helm template urbanos urbanos/urban-os --version "1.13.31" -f src/urbanos_demo_chart_values.yaml > helm_urbanos_template_output.yaml
+helm template urbanos urbanos/kafka --version "1.2.20" -f src/urbanos_kafka_values.yaml > helm_kafka_template_output.yaml
 
-echo "Template saved to \"helm_template_output.yaml\""
+echo "Template saved to \"helm_urbanos_template_output.yaml\" and \"helm_kafka_template_output.yaml\""

--- a/src/azure.ts
+++ b/src/azure.ts
@@ -8,7 +8,7 @@ import { DnsARecord } from "../.gen/providers/azurerm/dns-a-record";
 
 export const initializeAzureProvider = (classRef: TerraformStack) => {
   let credentials = {};
-  if (Config.demoMode) {
+  if (Config.azureTenant && Config.azurePassword && Config.azureAppID) {
     credentials = {
       subscriptionId: Config.azureSubID,
       clientId: Config.azureAppID,
@@ -16,7 +16,10 @@ export const initializeAzureProvider = (classRef: TerraformStack) => {
       tenantId: Config.azureTenant,
     };
   } else {
-    // use cli that's already been logged into with a local "az login"
+    // Attempt to use cli that's already been logged into with an "az login"
+    console.log(
+      "No azure credential set supplied, using the active Azure CLI user / tenant."
+    );
     credentials = {
       subscriptionId: Config.azureSubID,
     };

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,5 +1,24 @@
 ////////////////////////////////////////////////////////////////////////
 // Configuration
+
+private static getEnvVar(input: {
+  varName: string;
+  defaultValue?: string;
+  errorMsg?: string;
+}) {
+  const { varName, defaultValue, errorMsg } = input;
+  const envVar = process.env[varName];
+  if (envVar) {
+    return envVar;
+  } else if (defaultValue != undefined) {
+    return defaultValue;
+  } else {
+    throw Error(
+      `${varName} is not set in environment variables. ${errorMsg}`
+    );
+  }
+}
+
 export class Config {
   static get URLNoSuffix() {
     return this.getEnvVar({
@@ -51,19 +70,6 @@ export class Config {
     });
   }
 
-  // demoMode is intended for github actions execution and effecting
-  //     demo-urbanos.com resources. Should not be enabled in other
-  //     contexts or if developers are running the script locally for other
-  //     domains.
-  static get demoMode() {
-    return this.getEnvVar({
-      varName: "JUNO_DEMO_MODE_ENABLED",
-      defaultValue: "false",
-    }) === "true"
-      ? true
-      : false;
-  }
-
   static get auth0ApiKey() {
     return this.getEnvVar({
       varName: "AUTH0_USER_API_KEY",
@@ -71,37 +77,33 @@ export class Config {
     });
   }
 
-  // tag to put on all created resources, helpful for billing info + confirming
-  //     that resources related to this terraform has been entirely removed
-  static get tags() {
-    return {
-      environment: `${this.resourcePrefix}-terraform`,
-    };
-  }
-
   static get azureAppID() {
     return this.getEnvVar({
       varName: "JUNO_DEMO_AZURE_APP_ID",
-      errorMsg: "Required for azure login.",
-    });
-  }
-  static get azurePassword() {
-    return this.getEnvVar({
-      varName: "JUNO_DEMO_AZURE_PASSWORD",
-      errorMsg: "Required for azure login.",
-    });
-  }
-  static get azureTenant() {
-    return this.getEnvVar({
-      varName: "JUNO_DEMO_AZURE_TENANT",
-      errorMsg: "Required for azure login.",
+      defaultValue: ""
     });
   }
 
+  static get azurePassword() {
+    return this.getEnvVar({
+      varName: "JUNO_DEMO_AZURE_PASSWORD",
+      defaultValue: ""
+    });
+  }
+
+  static get azureTenant() {
+    return this.getEnvVar({
+      varName: "JUNO_DEMO_AZURE_TENANT",
+      defaultValue: ""
+    });
+  }
+
+  // if provided, store tf state in terraform.io
+  //     if omitted, use local state
   static get tfBackendKey() {
     return this.getEnvVar({
       varName: "JUNO_DEMO_TF_BACKEND_KEY",
-      errorMsg: "Required for remote tf state access.",
+      defaultValue: "",
     });
   }
 
@@ -118,22 +120,12 @@ export class Config {
       errorMsg: "UrbanOS requires auth0 client secret for Raptor service",
     });
   }
-
-  private static getEnvVar(input: {
-    varName: string;
-    defaultValue?: string;
-    errorMsg?: string;
-  }) {
-    const { varName, defaultValue, errorMsg } = input;
-    const envVar = process.env[varName];
-    if (envVar) {
-      return envVar;
-    } else if (defaultValue != undefined) {
-      return defaultValue;
-    } else {
-      throw Error(
-        `${varName} is not set in environment variables. ${errorMsg}`
-      );
-    }
+  
+  // tag to put on all created resources, helpful for billing info + confirming
+  //     that resources related to this terraform has been entirely removed
+  static get tags() {
+    return {
+      environment: `${this.resourcePrefix}-terraform`,
+    };
   }
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -107,6 +107,13 @@ export class Config {
     });
   }
 
+  static get tfWorkspaceName() {
+    return this.getEnvVar({
+      varName: "JUNO_DEMO_TF_WORKSPACE_NAME",
+      defaultValue: "",
+    });
+  }
+
   static get andiAuth0Secret() {
     return this.getEnvVar({
       varName: "JUNO_ANDI_AUTH0_CLIENT_SECRET",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,25 +1,25 @@
 ////////////////////////////////////////////////////////////////////////
 // Configuration
 
-private static getEnvVar(input: {
-  varName: string;
-  defaultValue?: string;
-  errorMsg?: string;
-}) {
-  const { varName, defaultValue, errorMsg } = input;
-  const envVar = process.env[varName];
-  if (envVar) {
-    return envVar;
-  } else if (defaultValue != undefined) {
-    return defaultValue;
-  } else {
-    throw Error(
-      `${varName} is not set in environment variables. ${errorMsg}`
-    );
-  }
-}
-
 export class Config {
+  private static getEnvVar(input: {
+    varName: string;
+    defaultValue?: string;
+    errorMsg?: string;
+  }) {
+    const { varName, defaultValue, errorMsg } = input;
+    const envVar = process.env[varName];
+    if (envVar) {
+      return envVar;
+    } else if (defaultValue != undefined) {
+      return defaultValue;
+    } else {
+      throw Error(
+        `${varName} is not set in environment variables. ${errorMsg}`
+      );
+    }
+  }
+
   static get URLNoSuffix() {
     return this.getEnvVar({
       varName: "JUNO_DOMAIN_NO_SUFFIX",
@@ -80,21 +80,21 @@ export class Config {
   static get azureAppID() {
     return this.getEnvVar({
       varName: "JUNO_DEMO_AZURE_APP_ID",
-      defaultValue: ""
+      defaultValue: "",
     });
   }
 
   static get azurePassword() {
     return this.getEnvVar({
       varName: "JUNO_DEMO_AZURE_PASSWORD",
-      defaultValue: ""
+      defaultValue: "",
     });
   }
 
   static get azureTenant() {
     return this.getEnvVar({
       varName: "JUNO_DEMO_AZURE_TENANT",
-      defaultValue: ""
+      defaultValue: "",
     });
   }
 
@@ -127,7 +127,16 @@ export class Config {
       errorMsg: "UrbanOS requires auth0 client secret for Raptor service",
     });
   }
-  
+
+  static get useStagingLetsEncrypt() {
+    return this.getEnvVar({
+      varName: "JUNO_USE_STAGING_LETS_ENCRYPT",
+      defaultValue: "false",
+    }).toLowerCase() === "true"
+      ? true
+      : false;
+  }
+
   // tag to put on all created resources, helpful for billing info + confirming
   //     that resources related to this terraform has been entirely removed
   static get tags() {

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -181,7 +181,7 @@ export const installStreamsToEventHub = (
   return new Release(classRef, "SteamsToEventHubRelease", {
     name: "streams-to-event-hub",
     chart: "streams-to-event-hub",
-    version: "0.0.6",
+    version: "0.0.7",
     repository: "https://urbanos-public.github.io/streams-to-event-hub",
     description:
       "Install of StreamsToEventHub using values from the Juno terraform repo. Installed with the helm provider.",

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -35,7 +35,12 @@ export const installUrbanOS = (
       "Install of UrbanOS using values from the Juno terraform repo. Installed with the helm provider.",
     namespace: "urbanos",
     createNamespace: false,
-    values: [loadFileContentsAsString("urbanos_demo_chart_values.yaml")],
+    values: [
+      loadFileContentsAsString("urbanos_demo_chart_values.yaml").replace(
+        "URL_W_SUFFIX",
+        Config.URLWithSuffix
+      ),
+    ],
     ...dependsOn,
     timeout: 600,
   });
@@ -156,6 +161,8 @@ export const installStreamsToEventHub = (
 ) => {
   const secrets = installStreamsToEventHubSecrets(classRef, dependsOn);
 
+  const sourceStreamsURL = `wss://streams.${Config.URLWithSuffix}/socket/websocket`;
+
   return new Release(classRef, "SteamsToEventHubRelease", {
     name: "streams-to-event-hub",
     chart: "streams-to-event-hub",
@@ -168,7 +175,7 @@ export const installStreamsToEventHub = (
     set: [
       {
         name: "sourceStreamsUrl",
-        value: "wss://streams.demo-urbanos.com/socket/websocket",
+        value: sourceStreamsURL,
       },
       {
         name: "streamsTopic",

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -218,6 +218,7 @@ export const installIngressNginx = (
     name: "ingress-nginx",
     chart: "ingress-nginx",
     repository: "https://kubernetes.github.io/ingress-nginx",
+    version: "4.6.0",
     description:
       "Install of ingress-nginx for making andi and the discovery suite applications available on the internet",
     namespace: "urbanos",
@@ -229,6 +230,10 @@ export const installIngressNginx = (
       {
         name: "controller.service.loadBalancerIP",
         value: ip.ipAddress,
+      },
+      {
+        name: "controller.admissionWebhooks.failurePolicy",
+        values: "Ignore",
       },
     ],
     ...dependsOn,

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -6,7 +6,7 @@ import { Release } from "../.gen/providers/helm/release";
 import { Manifest } from "../.gen/providers/kubectl/manifest";
 import { Config } from "./configuration";
 import { installMinioUser, installStreamsToEventHubSecrets } from "./kubectl";
-import { DependsOn, loadFileContentsAsString } from "./utils";
+import { DependsOn, loadFileContentsAsString, replaceAll } from "./utils";
 
 export const initializeHelm = (
   classRef: TerraformStack,
@@ -36,7 +36,8 @@ export const installUrbanOS = (
     namespace: "urbanos",
     createNamespace: false,
     values: [
-      loadFileContentsAsString("urbanos_demo_chart_values.yaml").replaceAll(
+      replaceAll(
+        loadFileContentsAsString("urbanos_demo_chart_values.yaml"),
         "URL_W_SUFFIX",
         Config.URLWithSuffix
       ),
@@ -263,7 +264,7 @@ export const installCertManager = (
     dependsOn: [release],
     yamlBody: loadFileContentsAsString(
       "resource_additions/cluster_issuer.yaml"
-    ).replaceAll("INJECT_CA_SERVER", CA_Server),
+    ).replace("INJECT_CA_SERVER", CA_Server),
   });
 
   return release;

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -233,7 +233,7 @@ export const installIngressNginx = (
       },
       {
         name: "controller.admissionWebhooks.failurePolicy",
-        values: "Ignore",
+        value: "Ignore",
       },
     ],
     ...dependsOn,

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -43,7 +43,7 @@ export const installUrbanOS = (
       ),
     ],
     ...dependsOn,
-    timeout: 600,
+    timeout: 300,
   });
 
 export const installKafka = (classRef: TerraformStack, dependsOn: DependsOn) =>

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -45,6 +45,21 @@ export const installUrbanOS = (
     timeout: 600,
   });
 
+export const installKafka = (classRef: TerraformStack, dependsOn: DependsOn) =>
+  new Release(classRef, "KafkaHelmRelease", {
+    name: "kafka",
+    chart: "kafka",
+    version: "1.2.20",
+    repository: "https://urbanos-public.github.io/charts/",
+    description:
+      "Install of Kafka using values from the Juno terraform repo. Installed with the helm provider.",
+    namespace: "urbanos",
+    createNamespace: false,
+    values: [loadFileContentsAsString("urbanos_kafka_values.yaml")],
+    ...dependsOn,
+    timeout: 600,
+  });
+
 export const installMinioOperator = (
   classRef: TerraformStack,
   dependsOn: DependsOn

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -36,7 +36,7 @@ export const installUrbanOS = (
     namespace: "urbanos",
     createNamespace: false,
     values: [
-      loadFileContentsAsString("urbanos_demo_chart_values.yaml").replace(
+      loadFileContentsAsString("urbanos_demo_chart_values.yaml").replaceAll(
         "URL_W_SUFFIX",
         Config.URLWithSuffix
       ),
@@ -263,7 +263,7 @@ export const installCertManager = (
     dependsOn: [release],
     yamlBody: loadFileContentsAsString(
       "resource_additions/cluster_issuer.yaml"
-    ).replace("INJECT_CA_SERVER", CA_Server),
+    ).replaceAll("INJECT_CA_SERVER", CA_Server),
   });
 
   return release;

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -236,11 +236,19 @@ export const installCertManager = (
     ...dependsOn,
   });
 
+  const letsEncryptProd = "https://acme-v02.api.letsencrypt.org/directory";
+  const letsEncryptStaging =
+    "https://acme-staging-v02.api.letsencrypt.org/directory";
+
+  const CA_Server = Config.useStagingLetsEncrypt
+    ? letsEncryptStaging
+    : letsEncryptProd;
+
   new Manifest(classRef, "CertIssuer", {
     dependsOn: [release],
     yamlBody: loadFileContentsAsString(
       "resource_additions/cluster_issuer.yaml"
-    ),
+    ).replace("INJECT_CA_SERVER", CA_Server),
   });
 
   return release;

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -3,7 +3,7 @@ import { KubernetesClusterKubeConfigOutputReference } from "../.gen/providers/az
 import { Manifest } from "../.gen/providers/kubectl/manifest";
 import { KubectlProvider } from "../.gen/providers/kubectl/provider";
 import { Config } from "./configuration";
-import { DependsOn, loadFileContentsAsString } from "./utils";
+import { DependsOn, loadFileContentsAsString, replaceAll } from "./utils";
 
 /////////////////////////////////////////////////////
 // connect with kubectl to install individual resources.
@@ -133,7 +133,7 @@ const installResource = (
   let yamlBody = loadFileContentsAsString(yamlFile);
 
   if (secretInject) {
-    yamlBody = yamlBody.replaceAll(secretInject.key, secretInject.value);
+    yamlBody = replaceAll(yamlBody, secretInject.key, secretInject.value);
   }
 
   return new Manifest(classRef, tfID, {

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -133,7 +133,7 @@ const installResource = (
   let yamlBody = loadFileContentsAsString(yamlFile);
 
   if (secretInject) {
-    yamlBody = yamlBody.replace(secretInject.key, secretInject.value);
+    yamlBody = yamlBody.replaceAll(secretInject.key, secretInject.value);
   }
 
   return new Manifest(classRef, tfID, {

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -49,7 +49,8 @@ export const installIngresses = (
       classRef,
       dependsOn,
       `${label}Ingress`,
-      `resource_additions/ingresses/${ingress_file}`
+      `resource_additions/ingresses/${ingress_file}`,
+      { key: "URL_W_SUFFIX", value: Config.URLWithSuffix }
     );
   });
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,7 @@ class MyStack extends TerraformStack {
     //     (Ingresses / Namespaces / etc.)
     initializeKubectlProvider(classRef, clusterKubeConf);
     const namespace = createUrbanOSNamespace(classRef, {
-      dependsOn: [cluster],
+      dependsOn: [cluster, medram, highram],
     });
 
     //////////////////////////////////////////////////////////////////////////

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,10 +129,6 @@ class MyStack extends TerraformStack {
 
     const mockCVEData = installMockCVEData(classRef, { dependsOn: [urbanos] });
 
-    // wait to install ingresses until mockCVE and urbanos are deployed, so that
-    //   service challenges pass when generating certs
-    installIngresses(classRef, { dependsOn: [ingressNginx, mockCVEData] });
-
     if (Config.eventHubURL) {
       console.log("EVENTHUB WILL BE INSTALLED");
       installStreamsToEventHub(classRef, {
@@ -141,6 +137,12 @@ class MyStack extends TerraformStack {
     } else {
       console.log("EVENTHUB WILL *NOT* BE INSTALLED");
     }
+
+    // wait to install ingresses until mockCVE and urbanos are deployed, so that
+    //   service challenges pass when generating certs
+    installIngresses(classRef, {
+      dependsOn: [ingressNginx, mockCVEData, urbanos],
+    });
 
     //////////////////////////////////////////////////////////////////////////
     // Outputs

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,10 +43,7 @@ class MyStack extends TerraformStack {
     super(scope, id);
     const classRef = this;
 
-    // DEMO_MODE is enabled only in the github workflow.
-    //     When not running in DEMO_MODE, aka running locally, a local state file
-    //     will be used instead of terraform cloud remote state.
-    if (Config.demoMode) initTFRemoteBackend(classRef);
+    if (Config.tfBackendKey) initTFRemoteBackend(classRef);
 
     ////////////////////////////////////////////////////////////////////////
     // Azure Setup

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,6 +129,10 @@ class MyStack extends TerraformStack {
 
     const mockCVEData = installMockCVEData(classRef, { dependsOn: [urbanos] });
 
+    // wait to install ingresses until mockCVE and urbanos are deployed, so that
+    //   service challenges pass when generating certs
+    installIngresses(classRef, { dependsOn: [ingressNginx, mockCVEData] });
+
     if (Config.eventHubURL) {
       console.log("EVENTHUB WILL BE INSTALLED");
       installStreamsToEventHub(classRef, {
@@ -137,10 +141,6 @@ class MyStack extends TerraformStack {
     } else {
       console.log("EVENTHUB WILL *NOT* BE INSTALLED");
     }
-
-    // wait to install ingresses until mockCVE and urbanos are deployed, so that
-    //   service challenges pass when generating certs
-    installIngresses(classRef, { dependsOn: [ingressNginx, mockCVEData] });
 
     //////////////////////////////////////////////////////////////////////////
     // Outputs

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,14 @@ class MyStack extends TerraformStack {
     super(scope, id);
     const classRef = this;
 
-    if (Config.tfBackendKey) initTFRemoteBackend(classRef);
+    if (Config.tfBackendKey && Config.tfWorkspaceName) {
+      console.log("Using remote TF backend:", Config.tfWorkspaceName);
+      initTFRemoteBackend(classRef);
+    } else {
+      console.log(
+        "Using local terraform state, since backend key or workspace name were not provided."
+      );
+    }
 
     ////////////////////////////////////////////////////////////////////////
     // Azure Setup

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import {
   installCertManager,
   installElasticsearch,
   installIngressNginx,
+  installKafka,
   installMinioOperator,
   installMinioTenant,
   installMockCVEData,
@@ -108,11 +109,15 @@ class MyStack extends TerraformStack {
       dependsOn: [namespace],
     });
 
+    const kafka = installKafka(classRef, {
+      dependsOn: [strimziCRDs],
+    });
+
     const urbanos = installUrbanOS(classRef, {
       dependsOn: [
         minioTenant,
         postgresql,
-        strimziCRDs,
+        kafka,
         auth0,
         redis,
         elasticsearch,

--- a/src/remote_tf_state.ts
+++ b/src/remote_tf_state.ts
@@ -8,7 +8,7 @@ export const initTFRemoteBackend = (classRef: TerraformStack) =>
     hostname: "app.terraform.io",
     organization: "benjaminmitchinson",
     workspaces: {
-      name: "juno-demo-workspace",
+      name: Config.tfWorkspaceName,
     },
     token: Config.tfBackendKey,
   });

--- a/src/resource_additions/cluster_issuer.yaml
+++ b/src/resource_additions/cluster_issuer.yaml
@@ -5,13 +5,7 @@ metadata:
   namespace: urbanos
 spec:
   acme:
-    server: https://acme-v02.api.letsencrypt.org/directory # prod
-    # server: https://acme-staging-v02.api.letsencrypt.org/directory # staging
-    # "staging" url works just as good as prod, but isn't considered a trusted
-    # CA :/
-    # prod letsencrypt usage limits: https://letsencrypt.org/docs/rate-limits/
-    # staging usage limits: https://letsencrypt.org/docs/staging-environment/
-    # if learning about caching certs, should practice first with staging.
+    server: INJECT_CA_SERVER
     email: benjamin.mitchinson@accenture.com
     privateKeySecretRef:
       name: letsencrypt

--- a/src/resource_additions/ingresses/andi.yaml
+++ b/src/resource_additions/ingresses/andi.yaml
@@ -9,10 +9,10 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - andi.demo-urbanos.com
+        - andi.URL_W_SUFFIX
       secretName: andi-tls-secret
   rules:
-    - host: andi.demo-urbanos.com
+    - host: andi.URL_W_SUFFIX
       http:
         paths:
           - path: /

--- a/src/resource_additions/ingresses/crash.yaml
+++ b/src/resource_additions/ingresses/crash.yaml
@@ -9,10 +9,10 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - crash.demo-urbanos.com
+        - crash.URL_W_SUFFIX
       secretName: crash-tls-secret
   rules:
-    - host: crash.demo-urbanos.com
+    - host: crash.URL_W_SUFFIX
       http:
         paths:
           - path: /

--- a/src/resource_additions/ingresses/discovery_api.yaml
+++ b/src/resource_additions/ingresses/discovery_api.yaml
@@ -9,10 +9,10 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - data.demo-urbanos.com
+        - data.URL_W_SUFFIX
       secretName: discovery-api-tls-secret
   rules:
-    - host: data.demo-urbanos.com
+    - host: data.URL_W_SUFFIX
       http:
         paths:
           - path: /

--- a/src/resource_additions/ingresses/discovery_streams.yaml
+++ b/src/resource_additions/ingresses/discovery_streams.yaml
@@ -9,10 +9,10 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - streams.demo-urbanos.com
+        - streams.URL_W_SUFFIX
       secretName: discovery-streams-tls-secret
   rules:
-    - host: streams.demo-urbanos.com
+    - host: streams.URL_W_SUFFIX
       http:
         paths:
           - path: /

--- a/src/resource_additions/ingresses/discovery_ui.yaml
+++ b/src/resource_additions/ingresses/discovery_ui.yaml
@@ -16,10 +16,10 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - discovery.demo-urbanos.com
+        - discovery.URL_W_SUFFIX
       secretName: discovery-tls-secret
   rules:
-    - host: discovery.demo-urbanos.com
+    - host: discovery.URL_W_SUFFIX
       http:
         paths:
           - path: /

--- a/src/urbanos_demo_chart_values.yaml
+++ b/src/urbanos_demo_chart_values.yaml
@@ -8,8 +8,8 @@ global:
   kafka:
     brokers: pipeline-kafka-bootstrap:9092
   ingress:
-    dnsZone: "demo-urbanos.com"
-    rootDnsZone: "demo-urbanos.com"
+    dnsZone: "URL_W_SUFFIX"
+    rootDnsZone: "URL_W_SUFFIX"
   buckets:
     hostedFileBucket: "hosted-dataset-files"
     hiveStorageBucket: "presto-hive-storage"
@@ -156,15 +156,15 @@ discovery-ui:
       memory: 500M
       cpu: 300m
   env:
-    disc_api_url: "https://data.demo-urbanos.com"
-    disc_streams_url: "ws://streams.demo-urbanos.com"
-    disc_ui_url: "http://discovery.demo-urbanos.com"
+    disc_api_url: "https://data.URL_W_SUFFIX"
+    disc_streams_url: "ws://streams.URL_W_SUFFIX"
+    disc_ui_url: "http://discovery.URL_W_SUFFIX"
     streets_tile_layer_url: ""
     mapbox_access_token: ""
     auth0_domain: "urbanos-demo.us.auth0.com"
     auth0_client_id: "3o2V7xHvmV2nQjp1HapX68DzWvxVQdJ2"
     auth0_audience: "discovery_api"
-    additional_csp_hosts: "*.demo-urbanos.com *.githubusercontent.com"
+    additional_csp_hosts: "*.URL_W_SUFFIX *.githubusercontent.com"
     footer_right_links: '[{"linkText":"Powered by UrbanOS", "url":"https://github.com/UrbanOS-Public"}]'
     regenerate_api_key_ff: true
 

--- a/src/urbanos_demo_chart_values.yaml
+++ b/src/urbanos_demo_chart_values.yaml
@@ -229,7 +229,8 @@ persistence:
           memory: 3000M
           cpu: 500m
 
-    # applies to worker and coordinator as of chart 0.8.0
+    # applies to both worker and coordinator as of chart 0.8.0, later versions
+    #   can set them independently
     # affinity:
     #     nodeAffinity:
     #       requiredDuringSchedulingIgnoredDuringExecution:

--- a/src/urbanos_demo_chart_values.yaml
+++ b/src/urbanos_demo_chart_values.yaml
@@ -171,41 +171,9 @@ discovery-ui:
 elasticsearch:
   enabled: false
 
+# installed prior to urbanos as a separate release with urbanos_kafka_values.yaml
 kafka:
-  enabled: true
-  strimzi-kafka-operator:
-    enabled: true
-    resources:
-      limits:
-        memory: 400M
-        cpu: 500m
-      requests:
-        memory: 400M
-        cpu: 500m
-  kafka:
-    enabled: true
-    storageSize: 4Gi
-    version: 3.1.2
-    defaultReplicas: 1
-    resources:
-      requests:
-        cpu: 500m
-        memory: 700M
-      limits:
-        cpu: 500m
-        memory: 700M
-  zookeeper:
-    resources:
-      requests:
-        cpu: 200m
-        memory: 500M
-      limits:
-        cpu: 200m
-        memory: 500M
-  kafkaExporter:
-    enabled: false
-  rbac:
-    enabled: false
+  enabled: false
 
 kubernetes-data-platform:
   enabled: false

--- a/src/urbanos_kafka_values.yaml
+++ b/src/urbanos_kafka_values.yaml
@@ -1,0 +1,33 @@
+strimzi-kafka-operator:
+  enabled: true
+  resources:
+    limits:
+      memory: 400M
+      cpu: 500m
+    requests:
+      memory: 400M
+      cpu: 500m
+kafka:
+  enabled: true
+  storageSize: 4Gi
+  version: 3.1.2
+  defaultReplicas: 1
+  resources:
+    requests:
+      cpu: 500m
+      memory: 700M
+    limits:
+      cpu: 500m
+      memory: 700M
+zookeeper:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 500M
+    limits:
+      cpu: 200m
+      memory: 500M
+kafkaExporter:
+  enabled: false
+rbac:
+  enabled: false

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,3 +6,11 @@ export type DependsOn = { dependsOn: ITerraformDependable[] };
 
 export const loadFileContentsAsString = (relativePath: string) =>
   readFileSync(path.resolve(__dirname, relativePath)).toString();
+
+export const replaceAll = (
+  string: string,
+  find: string,
+  replacement: string
+) => {
+  return string.replace(new RegExp(find, "g"), replacement);
+};


### PR DESCRIPTION
Passing deployment: https://github.com/UrbanOS-Public/juno/actions/runs/4815717671/jobs/8574657187

## Major 

- Install Kafka as a separate helm release, only if that succeeds, install UrbanOS
  - Hopefully this stabilizes some kafka race conditions where discovery-api was reporting healthy, but not listening to new datasets
- Added "staging certs mode" to "deploy-urbanos" workflow, to deploy a version of urban os that won't count towards the 5 prod certs a week.
  - Updated "streams-to-eventhub" to work with staging certs
- Added "environment" mode, to choose if you're deploying to "demo-urbanos.com", or the new "dev1-urbanos.com"
  - "dev1-urbanos.com" now exists to run juno tests / new juno changes, without interfearing with "demo-urbanos.com"

<img width="366" alt="image" src="https://user-images.githubusercontent.com/33632286/234753187-cc7bb50c-237e-461e-aea2-1edc373b2568.png">

## Minor

- Moved around .env file to match workflow files and github action env secrets. Added comments.
- removed useless "demo mode" configuration that didn't really do anything
- Made terraform workspace configurable to help with supporting multiple environment deployments
- Updated admissionWebhooks failure policy to ignore false failures
- Updated ingresses to reference configured target website address, no longer hard coded to demo-urbanos.com. 
- Wait to install namespace (aka: all helm installs) until all node pools are available

## Reminder

After this is merged, remove the "Actions" environment, that has been replaced now with a more appropriately named "demo-urbanos.com"