### PR TITLE
reverting client_id for demo version

### DIFF
--- a/envs/demo/urbanos_values.yaml
+++ b/envs/demo/urbanos_values.yaml
@@ -59,7 +59,7 @@ andi:
     password: "admin"
     verifySNI: false
   auth:
-    andi_auth0_client_id: "S3H3cToHVddG7Q7zEKK1nJbzrAy9GqG0"
+    auth0_client_id: "S3H3cToHVddG7Q7zEKK1nJbzrAy9GqG0"
     # {{ .Release.Name }}-andi-auth0-client-secret will be referenced,
     #   created ahead of time
     auth0_client_secret: ""
@@ -155,7 +155,7 @@ discovery-ui:
     streets_tile_layer_url: ""
     mapbox_access_token: ""
     auth0_domain: "urbanos-demo.us.auth0.com"
-    discovery_auth0_client_id: "3o2V7xHvmV2nQjp1HapX68DzWvxVQdJ2"
+    auth0_client_id: "3o2V7xHvmV2nQjp1HapX68DzWvxVQdJ2"
     auth0_audience: "discovery_api"
     additional_csp_hosts: "*.URL_W_SUFFIX *.githubusercontent.com"
     footer_right_links: '[{"linkText":"Powered by UrbanOS", "url":"https://github.com/UrbanOS-Public"}]'
@@ -264,6 +264,7 @@ raptor:
       cpu: 250m
       memory: 500M
   auth:
+    auth0_client_id: PuL20cfxgzSu6jpMRQAT2mZ2pwhfFzH8
     raptor_auth0_client_id: PuL20cfxgzSu6jpMRQAT2mZ2pwhfFzH8
     # {{ .Release.Name }}-andi-auth0-client-secret will be referenced,
     #   created ahead of time


### PR DESCRIPTION
Since Demo is pinned to an old version, the auth0_client_ids need to stay aligned. 